### PR TITLE
Mortal Kombat Deception example plugin

### DIFF
--- a/data/scripts/PLUGINS/43341C03-MKD-[SLES-52705]/PCSX2PluginDemo3.map
+++ b/data/scripts/PLUGINS/43341C03-MKD-[SLES-52705]/PCSX2PluginDemo3.map
@@ -1,0 +1,117 @@
+
+Memory Configuration
+
+Name             Origin             Length             Attributes
+*default*        0x0000000000000000 0xffffffffffffffff
+
+Linker script and memory map
+
+LOAD main.o
+                0x0000000002020000                BASE_ADDRESS = 0x2020000
+
+.text           0x0000000002020000       0x80
+                0x0000000002020000                _ftext = .
+ *(.text)
+ .text          0x0000000002020000       0x70 main.o
+                0x0000000002020000                hook_load_hero_model
+                0x0000000002020028                init
+ *(.text.*)
+ .text.startup  0x0000000002020070        0x8 main.o
+                0x0000000002020070                main
+ *(.gnu.linkonce.t*)
+ *(.init)
+ *(.fini)
+                0x0000000002020078        0x8 QUAD 0x0
+                [!provide]                        PROVIDE (_etext = .)
+                [!provide]                        PROVIDE (etext = .)
+
+.reginfo        0x0000000002020080       0x18
+ *(.reginfo)
+ .reginfo       0x0000000002020080       0x18 main.o
+
+.ctors
+ *crtbegin*.o(.ctors)
+ *(EXCLUDE_FILE(*crtend*.o) .ctors)
+ *(SORT_BY_NAME(.ctors.*))
+ *(.ctors)
+
+.dtors
+ *crtbegin*.o(.dtors)
+ *(EXCLUDE_FILE(*crtend*.o) .dtors)
+ *(SORT_BY_NAME(.dtors.*))
+ *(.dtors)
+
+.rodata
+ *(.rodata)
+ *(.rodata.*)
+ *(.gnu.linkonce.r*)
+
+.MIPS.abiflags  0x0000000002020080       0x18
+ .MIPS.abiflags
+                0x0000000002020080       0x18 main.o
+
+.data           0x0000000002020100        0x0
+                0x0000000002020100                _fdata = .
+ *(.data)
+ .data          0x0000000002020100        0x0 main.o
+ *(.data.*)
+ *(.gnu.linkonce.d*)
+
+.rdata
+ *(.rdata)
+
+.gcc_except_table
+ *(.gcc_except_table)
+                0x00000000020280f0                _gp = (ALIGN (0x80) + 0x7ff0)
+
+.lit4
+ *(.lit4)
+
+.lit8
+ *(.lit8)
+
+.sdata
+ *(.sdata)
+ *(.sdata.*)
+ *(.gnu.linkonce.s*)
+                0x0000000002020100                _edata = .
+                [!provide]                        PROVIDE (edata = .)
+
+.sbss           0x0000000002020100        0x0
+                0x0000000002020100                _fbss = .
+ *(.sbss)
+ *(.sbss.*)
+ *(.gnu.linkonce.sb*)
+ *(.scommon)
+
+.bss            0x0000000002020100       0x6c
+ *(.bss)
+ .bss           0x0000000002020100       0x6c main.o
+                0x0000000002020100                load_hero_model
+                0x0000000002020108                PluginData
+ *(.bss.*)
+ *(.gnu.linkonce.b*)
+ *(COMMON)
+                0x000000000202016c                _end_bss = .
+                0x000000000202016c                _end = .
+                [!provide]                        PROVIDE (end = .)
+                [!provide]                        PROVIDE (_heap_size = 0xffffffffffffffff)
+                [!provide]                        PROVIDE (_stack = 0xffffffffffffffff)
+                [!provide]                        PROVIDE (_stack_size = 0x20000)
+OUTPUT(../../data/scripts/PLUGINS/43341C03-MKD-[SLES-52705]/PCSX2PluginDemo3.elf elf32-nlittlemips)
+
+.pdr            0x0000000000000000       0x60
+ .pdr           0x0000000000000000       0x60 main.o
+
+.mdebug.abiN32  0x0000000000000000        0x0
+ .mdebug.abiN32
+                0x0000000000000000        0x0 main.o
+
+.comment        0x0000000000000000       0x12
+ .comment       0x0000000000000000       0x12 main.o
+                                         0x13 (size before relaxing)
+
+.gnu.attributes
+                0x0000000000000000       0x10
+ .gnu.attributes
+                0x0000000000000000       0x10 main.o

--- a/premake5.lua
+++ b/premake5.lua
@@ -129,6 +129,15 @@ project "PCSX2PluginDemo2"
    setbuildpaths_ps2("Z:/GitHub/pcsx2/bin/", "pcsx2x64.exe", "scripts/PLUGINS/C0498D24-SCDA-[SLUS-21356]/", "%{wks.location}/../external/ps2sdk/ee/bin/vsmake", "%{wks.location}/../source/%{prj.name}/", "PCSX2PluginDemo2")
    writemakefile("PCSX2PluginDemo2", "scripts/PLUGINS/C0498D24-SCDA-[SLUS-21356]/", "0x02020000")
    writelinkfile("PCSX2PluginDemo2")
+
+project "PCSX2PluginDemo3"
+   kind "Makefile"
+   includedirs { "external/ps2sdk/ps2sdk/ee" }
+   files { "source/%{prj.name}/*.c" }
+   targetextension ".elf"
+   setbuildpaths_ps2("Z:/GitHub/pcsx2/bin/", "pcsx2x64.exe", "scripts/PLUGINS/43341C03-MKD-[SLES-52705]/", "%{wks.location}/../external/ps2sdk/ee/bin/vsmake", "%{wks.location}/../source/%{prj.name}/", "PCSX2PluginDemo3")
+   writemakefile("PCSX2PluginDemo3", "scripts/PLUGINS/43341C03-MKD-[SLES-52705]/", "0x02020000")
+   writelinkfile("PCSX2PluginDemo3")
    
 project "PCSX2PluginDummy"
    kind "Makefile"

--- a/readme.md
+++ b/readme.md
@@ -22,9 +22,13 @@
         │       PCSX2PluginDemo.elf
         │       PCSX2PluginDemo.ini
         │
-        └───C0498D24-SCDA-[SLUS-21356]
-                PCSX2PluginDemo2.elf
-                PCSX2PluginDemo2.ini
+        ├───C0498D24-SCDA-[SLUS-21356]
+        │       PCSX2PluginDemo2.elf
+        │       PCSX2PluginDemo2.ini
+		│		
+        └───43341C03-MKD-[SLES-52705]
+                PCSX2PluginDemo3.elf			
+				
 ```
 
  - **Enable 128 MB of RAM** option in PCSX2 settings should be set to **on** in order to use plugins.
@@ -53,6 +57,10 @@ ElfPattern = 10 00 BF FF 00 00 B0 7F 30 00 A4 AF 40 00 A5 AF
 - Demo Plugin 2 is for **Splinter Cell Double Agent [SLUS-21356]**, it makes the game stretched via redirecting code to plugin's function:
 
 ![](https://i.imgur.com/rBmx5Pc.png)
+
+- Demo Plugin 3 is for **Mortal Kombat: Deception [SLES-52705]**, disables intro movies and makes Konquest protagonist always use young model:
+
+![](https://i.imgur.com/VWptXcv.png)
 
 Log example:
 

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@
         ├───C0498D24-SCDA-[SLUS-21356]
         │       PCSX2PluginDemo2.elf
         │       PCSX2PluginDemo2.ini
-		│		
+		│
         └───43341C03-MKD-[SLES-52705]
                 PCSX2PluginDemo3.elf			
 				

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@
         ├───C0498D24-SCDA-[SLUS-21356]
         │       PCSX2PluginDemo2.elf
         │       PCSX2PluginDemo2.ini
-		│
+	│
         └───43341C03-MKD-[SLES-52705]
                 PCSX2PluginDemo3.elf			
 				

--- a/source/PCSX2PluginDemo3/main.c
+++ b/source/PCSX2PluginDemo3/main.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+#include <stdint.h>
+
+char PluginData[100] = { 0 };
+
+int(*load_hero_model)(int ptr);
+
+int hook_load_hero_model(int ptr)
+{
+	int* gp = (int*)0x5EA000;
+	int p_konquest_info = (*(gp + 209));
+
+	*(char*)(p_konquest_info + 92) = 1;
+
+	return load_hero_model(ptr);
+}
+
+void init()
+{
+	load_hero_model = (void*)0x303A90;
+	// skip intro
+    *(int*)0x1980F8 = 0; 
+    *(int*)0x197DF8 = 0;
+	// make shujinko young
+	*(int*)0x3039E0 = ((0x0C000000 | (((uint32_t)hook_load_hero_model & 0x0fffffff) >> 2))); //jal
+	*(int*)0x3B16C4 = ((0x0C000000 | (((uint32_t)hook_load_hero_model & 0x0fffffff) >> 2))); //jal
+}
+
+int main()
+{
+    return 0;
+}

--- a/source/PCSX2PluginDemo3/makefile
+++ b/source/PCSX2PluginDemo3/makefile
@@ -1,0 +1,13 @@
+EE_BIN = ../../data/scripts/PLUGINS/43341C03-MKD-[SLES-52705]/PCSX2PluginDemo3.elf
+EE_OBJS = main.o 
+
+BASE_ADDRESS = 0x02020000
+EE_LINKFILE = linkfile
+#EE_LIBS += -l:libc.a -l:libps2sdkc.a -l:libkernel.a
+EE_LDFLAGS = -Wl,--entry=init -Wl,-Map,../../data/scripts/PLUGINS/43341C03-MKD-[SLES-52705]/PCSX2PluginDemo3.map -nostdlib -nodefaultlibs -Wl,'--defsym=BASE_ADDRESS=$(BASE_ADDRESS)'
+
+all: $(EE_BIN)
+
+PS2SDK = ../../external/ps2sdk/ps2sdk
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.eeglobal


### PR DESCRIPTION
Skips intro movies and makes protagonist use young model in Konquest mode.